### PR TITLE
change pickaxe to netherite

### DIFF
--- a/plugins/ConsumeScrolls/config.yml
+++ b/plugins/ConsumeScrolls/config.yml
@@ -67,7 +67,7 @@ scrolls:
         itemstack:
           ==: org.bukkit.inventory.ItemStack
           v: 19
-          type: DIAMOND_PICKAXE
+          type: NETHERITE_PICKAXE
           meta:
             ==: ItemMeta
             meta-type: UNSPECIFIC


### PR DESCRIPTION
due to smithing table being disabled and the pickaxe having unobtainable enchants, i don't see why it wouldn't also be netherite, it just seems like blue balls not to.